### PR TITLE
Add 16 bit pooling support to TFLM

### DIFF
--- a/tensorflow/lite/micro/kernels/pooling.cc
+++ b/tensorflow/lite/micro/kernels/pooling.cc
@@ -42,6 +42,9 @@ TfLiteStatus AverageEval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteFloat32:
       AveragePoolingEvalFloat(context, node, params, data, input, output);
       break;
+    case kTfLiteInt16:
+      AveragePoolingEvalQuantized16(context, node, params, data, input, output);
+      break;
     case kTfLiteInt8:
       AveragePoolingEvalQuantized(context, node, params, data, input, output);
       break;
@@ -69,6 +72,9 @@ TfLiteStatus MaxEval(TfLiteContext* context, TfLiteNode* node) {
   switch (input->type) {
     case kTfLiteFloat32:
       MaxPoolingEvalFloat(context, node, params, data, input, output);
+      break;
+    case kTfLiteInt16:
+      MaxPoolingEvalQuantized16(context, node, params, data, input, output);
       break;
     case kTfLiteInt8:
       MaxPoolingEvalQuantized(context, node, params, data, input, output);

--- a/tensorflow/lite/micro/kernels/pooling.h
+++ b/tensorflow/lite/micro/kernels/pooling.h
@@ -56,6 +56,13 @@ void AveragePoolingEvalQuantized(TfLiteContext* context, const TfLiteNode* node,
                                  const TfLiteEvalTensor* input,
                                  TfLiteEvalTensor* output);
 
+void AveragePoolingEvalQuantized16(TfLiteContext* context,
+                                   const TfLiteNode* node,
+                                   const TfLitePoolParams* params,
+                                   const OpDataPooling* data,
+                                   const TfLiteEvalTensor* input,
+                                   TfLiteEvalTensor* output);
+
 void MaxPoolingEvalFloat(TfLiteContext* context, TfLiteNode* node,
                          TfLitePoolParams* params, const OpDataPooling* data,
                          const TfLiteEvalTensor* input,
@@ -66,6 +73,12 @@ void MaxPoolingEvalQuantized(TfLiteContext* context, TfLiteNode* node,
                              const OpDataPooling* data,
                              const TfLiteEvalTensor* input,
                              TfLiteEvalTensor* output);
+
+void MaxPoolingEvalQuantized16(TfLiteContext* context, TfLiteNode* node,
+                               TfLitePoolParams* params,
+                               const OpDataPooling* data,
+                               const TfLiteEvalTensor* input,
+                               TfLiteEvalTensor* output);
 
 #if defined(CMSIS_NN)
 TfLiteRegistration Register_AVERAGE_POOL_2D_INT8();


### PR DESCRIPTION
Add 16 bit pooling support to TFLM. TFLite already supported it, and so did the reference integer kernels. This PR was made such that we can test our own code against TFLM.